### PR TITLE
Looser peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "css-select": "^2.0.2"
   },
   "peerDependencies": {
-    "vue": "~2.5.13"
+    "vue": "^2.5.13"
   }
 }


### PR DESCRIPTION
installation with vue 2.7 does not require `--legacy-peer-deps` this way